### PR TITLE
Change get_completed_trades success condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2020-12-15
+### Changed
+- Only consider success for `get_completed_trades` if it meets certain criteria
+
 ## [1.1.0] - 2020-11-25
 ### Added
 - Add support for passing in `page` for completed trades

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    paxful_client (1.1.0)
+    paxful_client (1.2.0)
       activesupport
       api_client_base
       dry-validation (~> 0.13)
@@ -10,12 +10,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.4)
+    activesupport (6.1.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     api_client_base (1.9.0)
@@ -42,7 +42,7 @@ GEM
     dry-container (0.7.2)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.4.10)
+    dry-core (0.5.0)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.3.0)
     dry-inflector (0.2.0)
@@ -97,8 +97,8 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.8)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.3)
+      concurrent-ruby (~> 1.0)
     vcr (3.0.3)
     virtus (1.0.5)
       axiom-types (~> 0.1)
@@ -109,7 +109,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    zeitwerk (2.4.1)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/lib/paxful_client/responses/get_completed_trades_response.rb
+++ b/lib/paxful_client/responses/get_completed_trades_response.rb
@@ -22,5 +22,12 @@ module PaxfulClient
       order_book
     end
 
+    def default_success
+      code == 200 &&
+        !parsed_body.nil? &&
+        !parsed_body["data"].nil? &&
+        !parsed_body["data"]["trades"].nil?
+    end
+
   end
 end

--- a/lib/paxful_client/responses/get_completed_trades_response.rb
+++ b/lib/paxful_client/responses/get_completed_trades_response.rb
@@ -23,8 +23,11 @@ module PaxfulClient
     end
 
     def default_success
-      code == 200 &&
-        !parsed_body.nil? &&
+      code == 200 && present_parsed_body?
+    end
+
+    def present_parsed_body?
+      !parsed_body.nil? &&
         !parsed_body["data"].nil? &&
         !parsed_body["data"]["trades"].nil?
     end

--- a/lib/paxful_client/version.rb
+++ b/lib/paxful_client/version.rb
@@ -1,3 +1,3 @@
 module PaxfulClient
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/spec/fixtures/vcr_cassettes/Get_completed_trades/returns_the_completed_trades.yml
+++ b/spec/fixtures/vcr_cassettes/Get_completed_trades/returns_the_completed_trades.yml
@@ -55,7 +55,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"success":false,"message":"Not found"}'
-    http_version:
+    http_version: 
   recorded_at: Mon, 12 Oct 2020 08:40:52 GMT
 - request:
     method: get
@@ -112,14 +112,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"success":false,"message":"Not found"}'
-    http_version:
+    http_version: 
   recorded_at: Mon, 12 Oct 2020 08:43:35 GMT
 - request:
     method: post
     uri: "[host]/trade/completed"
     body:
       encoding: UTF-8
-      string: apikey=[key]&nonce=1606294092&page=1&apiseal=18f560d7707f7cdbf115b52178602e0c00d5a363949ad05f6d6f8380300782b9
+      string: apikey=[key]&nonce=1608024600&page=1&apiseal=fc1300509ac26d19ce36822daf6ac26531d76a4b9eae06a3b484f52fa734bee1
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus
@@ -135,29 +135,27 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 25 Nov 2020 08:48:13 GMT
+      - Tue, 15 Dec 2020 09:30:01 GMT
       Content-Type:
       - application/json
       Set-Cookie:
-      - __cf_bm=d951a918b13fb96919d4e35b71f38b9c720baec2-1606294093-1800-Af823WO8TfEUxKTRkR9Bp0GrlMdzYS9q4xw9PZfdp8BkKAyh8ZjDDDHaUO3ufaD/gDafQGO7R0y8d1rykhe4Ets=;
-        path=/; expires=Wed, 25-Nov-20 09:18:13 GMT; domain=.paxful.com; HttpOnly;
+      - __cf_bm=66624b361e58f44ef2cf4c0ed0414d9899a681ea-1608024601-1800-AcBFO9FupNjzcvvorOjn4M58QwdmIY6AJN1SU7yBimMykCMtwGrb8iylGQgVwUirPQ585bMP0IxliEgv6TM4Zv8=;
+        path=/; expires=Tue, 15-Dec-20 10:00:01 GMT; domain=.paxful.com; HttpOnly;
         Secure; SameSite=None
-      - __cfduid=d7134b42c6d1574627c830a726e3d07eb1606294092; expires=Fri, 25-Dec-20
-        08:48:12 GMT; path=/; domain=.paxful.com; HttpOnly; SameSite=Lax
-      - __cflb=02DiuJc4sPDmgGhTNdPy7cZ2sNmKt1vEdzBoB6WBmBNSQ; SameSite=Lax; path=/;
-        expires=Thu, 26-Nov-20 07:48:13 GMT; HttpOnly
+      - __cfduid=de47d240e17cde74a90a6c2c6648252ae1608024601; expires=Thu, 14-Jan-21
+        09:30:01 GMT; path=/; domain=.paxful.com; HttpOnly; SameSite=Lax
+      - __cflb=02DiuJc4sPDmgGhTNdPAoBuf263XWhoXuK54wC4Co2i1S; SameSite=Lax; path=/;
+        expires=Wed, 16-Dec-20 08:30:01 GMT; HttpOnly
       Cf-Ray:
-      - 5f7a1bff28e260fa-MNL
+      - 601f24bf7c7e058d-LAX
       Cache-Control:
       - no-cache, private
       Cf-Cache-Status:
       - DYNAMIC
       Cf-Request-Id:
-      - 06a02fd37a000060fa3521b000000001
+      - 0707554bae0000058dcd94c000000001
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      X-Castle-User-Id:
-      - 8b2805fa-fd69-4d15-9115-66a68a48bebe
       X-External-User-Id:
       - 8b2805fa-fd69-4d15-9115-66a68a48bebe
       X-Frame-Options:
@@ -165,214 +163,214 @@ http_interactions:
       X-Ratelimit-Limit:
       - '1000'
       X-Ratelimit-Remaining:
-      - '748'
+      - '771'
       X-User-Id:
       - '2919548'
       Server:
       - cloudflare
     body:
       encoding: UTF-8
-      string: '{"status":"success","timestamp":1606294092,"data":{"count":100,"page":1,"trades":[{"trade_hash":"5nsGsDNJPtR","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"13500.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1469691,"started_at":"2020-11-25 07:09:47","seller":"Bloomx","buyer":"grceph","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        08:46:38","completed_at":"2020-11-25 08:46:38","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"jiuj76triWx","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.95","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5439946,"started_at":"2020-11-25 06:49:30","seller":"Bloomx","buyer":"XJun","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        07:00:14","completed_at":"2020-11-25 07:00:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"bAdze8xc3um","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"11000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1208369,"started_at":"2020-11-25 05:06:19","seller":"Bloomx","buyer":"TrimKoel576","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        05:24:14","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"awb5Nwop9Uc","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"11000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1198629,"started_at":"2020-11-25 04:34:29","seller":"Bloomx","buyer":"TrimKoel576","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        05:04:31","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"7Gw1YR7ebox","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2500.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":274214,"started_at":"2020-11-25 04:00:30","seller":"Bloomx","buyer":"Marlyne46","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        04:11:29","completed_at":"2020-11-25 04:11:29","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"iA7UiUAdQob","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.96","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5437023,"started_at":"2020-11-25 03:54:14","seller":"Bloomx","buyer":"Gabrielteo2014","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        04:02:57","completed_at":"2020-11-25 04:02:57","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"MFELdzoiazU","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.97","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5409027,"started_at":"2020-11-25 03:21:40","seller":"Bloomx","buyer":"HeartyKite67","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        03:46:21","completed_at":"2020-11-25 03:46:21","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"4RSUxvssvhw","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.98","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5415125,"started_at":"2020-11-25 03:14:34","seller":"Bloomx","buyer":"Himatraders","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        03:45:26","completed_at":"2020-11-25 03:45:26","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"HpzBwVdPkVk","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.99","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5415126,"started_at":"2020-11-25 03:14:27","seller":"Bloomx","buyer":"Gabcess","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        03:16:19","completed_at":"2020-11-25 03:16:19","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"CsviaTtYLs9","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":324790,"started_at":"2020-11-25 02:34:54","seller":"Bloomx","buyer":"HumaneCombfish556","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        03:01:22","completed_at":"2020-11-25 03:01:22","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"Zhrt65Lvvqa","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":216526,"started_at":"2020-11-25 02:48:58","seller":"Bloomx","buyer":"SANJIKUN611","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        02:50:02","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"1KBuk7b3L72","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":963951,"started_at":"2020-11-25 01:18:41","seller":"Bloomx","buyer":"Osmak4real","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        01:58:18","completed_at":"2020-11-25 01:58:18","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"NRwP4PiwXT8","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5277128,"started_at":"2020-11-25 01:50:18","seller":"Bloomx","buyer":"SabAggabao05","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        01:54:14","completed_at":"2020-11-25 01:54:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"vzTrgfYHmze","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":963906,"started_at":"2020-11-25 00:16:30","seller":"Bloomx","buyer":"Osmak4real","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        00:17:40","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"szuuWgCLiyS","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":214201,"started_at":"2020-11-25 00:11:55","seller":"Bloomx","buyer":"LestreX7","fiat_currency_code":"PHP","ended_at":"2020-11-25
-        00:12:20","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"RotTcPbJTtR","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"35000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":3765499,"started_at":"2020-11-24 23:00:48","seller":"Bloomx","buyer":"Benlet0428","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        23:03:13","completed_at":"2020-11-24 23:03:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"EyJqxdhgBSq","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1591976,"started_at":"2020-11-24 15:04:10","seller":"Bloomx","buyer":"henriex","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        15:06:13","completed_at":"2020-11-24 15:06:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"rmJzsBDzmDW","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"81000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":8585644,"started_at":"2020-11-24 14:59:34","seller":"Bloomx","buyer":"henriex","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        15:02:13","completed_at":"2020-11-24 15:02:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"asFKVonqvn2","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"81000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":8585644,"started_at":"2020-11-24 14:57:12","seller":"Bloomx","buyer":"henriex","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        14:58:20","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"NGKzsERFmR9","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6200.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":671595,"started_at":"2020-11-24 10:08:00","seller":"Bloomx","buyer":"JayS3333","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        12:37:24","completed_at":"2020-11-24 12:37:24","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"VCE8pjyjaHN","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4900.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":529465,"started_at":"2020-11-24 12:01:23","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        12:04:12","completed_at":"2020-11-24 12:04:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"NnwGDjinZw3","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1630321,"started_at":"2020-11-24 09:59:31","seller":"Bloomx","buyer":"Tmarf2530","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        10:27:58","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"fic9xHdnN3Y","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2173761,"started_at":"2020-11-24 09:52:18","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        09:54:14","completed_at":"2020-11-24 09:54:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"RMuWhEFkM58","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":217376,"started_at":"2020-11-24 09:51:13","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        09:52:11","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"f25xAej1vHh","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4900.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":543256,"started_at":"2020-11-24 08:45:44","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        08:49:14","completed_at":"2020-11-24 08:49:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"epsQX9aRvNu","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"19500.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2173743,"started_at":"2020-11-24 08:15:12","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        08:45:16","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"9fpHTkhNXgr","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"40000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":4470580,"started_at":"2020-11-24 08:05:09","seller":"Bloomx","buyer":"Jensonzia568","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        08:43:42","completed_at":"2020-11-24 08:43:42","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"b53Lv79G5Q3","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9500.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1053252,"started_at":"2020-11-24 08:40:57","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        08:43:16","completed_at":"2020-11-24 08:43:16","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"smfKUpkEn19","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9500.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1056335,"started_at":"2020-11-24 08:35:08","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        08:37:17","completed_at":"2020-11-24 08:37:17","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"zBsvap9qpvu","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"17000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1895058,"started_at":"2020-11-24 08:14:08","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        08:17:18","completed_at":"2020-11-24 08:17:18","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"ABVhJQhtprZ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4985.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":556509,"started_at":"2020-11-24 07:47:05","seller":"Bloomx","buyer":"Aquinas53","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        08:17:09","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"2MnhiM2vXKn","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"40000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":4458959,"started_at":"2020-11-24 08:11:12","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        08:13:33","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"ssnokFvr2Km","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"68000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":7594335,"started_at":"2020-11-24 07:12:29","seller":"Bloomx","buyer":"JimpReedfish11","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        07:42:32","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"Wgmu5d8gzkN","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4985.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":557694,"started_at":"2020-11-24 07:07:18","seller":"Bloomx","buyer":"Aquinas53","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        07:37:19","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"oXhr9zEfD9H","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"68000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":7607460,"started_at":"2020-11-24 07:04:23","seller":"Bloomx","buyer":"ClearAmago893","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        07:34:27","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"yyAHWJWBkn2","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2233628,"started_at":"2020-11-24 07:14:19","seller":"Bloomx","buyer":"Osmak4real","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        07:27:35","completed_at":"2020-11-24 07:27:35","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"svxyont6zjM","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"25000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2796860,"started_at":"2020-11-24 07:08:38","seller":"Bloomx","buyer":"Osmak4real","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        07:14:09","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"9svyvpKht6F","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2246958,"started_at":"2020-11-24 06:42:32","seller":"Bloomx","buyer":"HeartyWoodhen362","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        07:12:36","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"4sUEhS7AvVV","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"29000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":3252805,"started_at":"2020-11-24 06:57:49","seller":"Bloomx","buyer":"Osmak4real","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        07:04:02","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"vnrXLqNgrcC","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"68000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":7638735,"started_at":"2020-11-24 06:32:55","seller":"Bloomx","buyer":"ClearAmago893","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        07:02:58","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"uiSpMBm4vUF","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"25000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2804142,"started_at":"2020-11-24 06:50:55","seller":"Bloomx","buyer":"Osmak4real","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        06:56:04","completed_at":"2020-11-24 06:56:04","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"Az9zYSjyMrM","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"54000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":6066787,"started_at":"2020-11-24 06:43:54","seller":"Bloomx","buyer":"Osmak4real","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        06:49:39","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"R8aXUmZnVrm","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":557319,"started_at":"2020-11-24 05:44:41","seller":"Bloomx","buyer":"Loracaryn","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        05:50:12","completed_at":"2020-11-24 05:50:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"p7zVTEd5j9m","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"28400.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":3168672,"started_at":"2020-11-24 05:31:37","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        05:33:12","completed_at":"2020-11-24 05:33:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"rdhjnyYjxyB","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"300000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":33518969,"started_at":"2020-11-24 04:26:12","seller":"Bloomx","buyer":"Markhy969","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        04:46:50","completed_at":"2020-11-24 04:46:50","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"uLNSBEtJXni","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"17300.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1933506,"started_at":"2020-11-24 04:38:26","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        04:41:13","completed_at":"2020-11-24 04:41:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"npY111LKFYc","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.97","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5574904,"started_at":"2020-11-24 03:29:15","seller":"Bloomx","buyer":"Gabrielteo2014","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        03:40:12","completed_at":"2020-11-24 03:40:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"6dmNUHhPrUJ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.99","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5574907,"started_at":"2020-11-24 03:22:51","seller":"Bloomx","buyer":"Himatraders","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        03:39:49","completed_at":"2020-11-24 03:39:49","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"rgXgdCeZQeJ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.98","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5575997,"started_at":"2020-11-24 03:30:28","seller":"Bloomx","buyer":"Gabcess","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        03:32:14","completed_at":"2020-11-24 03:32:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"Qb27jezsf2z","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.99","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5604509,"started_at":"2020-11-23 03:56:59","seller":"Bloomx","buyer":"Gabcess","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        03:58:22","completed_at":"2020-11-23 03:58:22","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"RNuVPYH8Z3f","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"28000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":3120072,"started_at":"2020-11-24 02:12:25","seller":"Bloomx","buyer":"Coinspot70","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        02:24:56","completed_at":"2020-11-24 02:24:56","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"FXQdA5bF3DL","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1112213,"started_at":"2020-11-24 01:10:11","seller":"Bloomx","buyer":"Momcare12","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        01:40:12","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"CPMDayrZXky","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9530.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1064988,"started_at":"2020-11-24 01:05:55","seller":"Bloomx","buyer":"emmanuelnaji","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        01:35:58","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"Nu2vxisj8sd","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"40000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":4470044,"started_at":"2020-11-24 01:05:47","seller":"Bloomx","buyer":"BonzerPilchard450","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        01:35:49","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"Ks2cv5NvoEc","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1123964,"started_at":"2020-11-24 00:37:29","seller":"Bloomx","buyer":"Momcare12","fiat_currency_code":"PHP","ended_at":"2020-11-24
-        01:07:30","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"qR362y9gw77","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":223134,"started_at":"2020-11-23 23:39:19","seller":"Bloomx","buyer":"themariacarla","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        23:41:37","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"nv36dVYTrjz","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"30000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":3347016,"started_at":"2020-11-23 23:32:23","seller":"Bloomx","buyer":"Benlet0428","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        23:38:14","completed_at":"2020-11-23 23:38:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"ExonmhTPQiy","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"26000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2900747,"started_at":"2020-11-23 23:34:35","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        23:37:12","completed_at":"2020-11-23 23:37:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"boi2v1pJ27V","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5100.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":567367,"started_at":"2020-11-23 23:00:57","seller":"Bloomx","buyer":"Lyovochka","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        23:01:45","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"wkiEwX83Kvm","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1118043,"started_at":"2020-11-23 18:25:29","seller":"Bloomx","buyer":"JauntyTrogon865","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        18:26:37","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"qW3ixbycugh","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"40000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":4475992,"started_at":"2020-11-23 17:33:42","seller":"Bloomx","buyer":"AvidBurbot88","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        17:34:27","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"qQukPp6BGbe","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"100000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":11241502,"started_at":"2020-11-23 16:58:09","seller":"Bloomx","buyer":"kingb12","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        17:00:13","completed_at":"2020-11-23 17:00:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"qCnsrDN4pjY","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2255264,"started_at":"2020-11-23 16:46:32","seller":"Bloomx","buyer":"Nerraw","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        16:48:31","completed_at":"2020-11-23 16:48:31","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"frk1XVwiPCL","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"26000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2873936,"started_at":"2020-11-23 14:26:10","seller":"Bloomx","buyer":"SabAggabao05","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        14:27:24","completed_at":"2020-11-23 14:27:24","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"mMvjd4zovA1","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9500.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1046218,"started_at":"2020-11-23 13:15:14","seller":"Bloomx","buyer":"Ranger0123","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        13:45:15","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"VQggZ6Shsaa","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"54888.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":6050307,"started_at":"2020-11-23 13:09:38","seller":"Bloomx","buyer":"CNDYBT","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        13:14:16","completed_at":"2020-11-23 13:14:16","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"F1xiHWJmgM4","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2209223,"started_at":"2020-11-23 12:46:39","seller":"Bloomx","buyer":"XenialSnipe833","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        12:47:28","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"rEMyo9pn2hA","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"26000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2884805,"started_at":"2020-11-23 12:35:48","seller":"Bloomx","buyer":"SabAggabao05","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        12:45:46","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"Zo81XeqSEqh","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2209223,"started_at":"2020-11-23 12:44:28","seller":"Bloomx","buyer":"XenialSnipe833","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        12:44:49","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"mSvVW38D6pv","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2219080,"started_at":"2020-11-23 12:38:17","seller":"Bloomx","buyer":"XenialSnipe833","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        12:43:53","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"1vLnKXpHpf9","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":998586,"started_at":"2020-11-23 12:33:25","seller":"Bloomx","buyer":"escorpi","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        12:38:15","completed_at":"2020-11-23 12:38:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"nLUdFJwGaJs","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":555385,"started_at":"2020-11-23 12:23:30","seller":"Bloomx","buyer":"MangMario","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        12:24:53","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"HdBy5NhMygJ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"31599.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":3491191,"started_at":"2020-11-23 12:02:08","seller":"Bloomx","buyer":"CNDYBT","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        12:06:14","completed_at":"2020-11-23 12:06:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"f85sfLaS47k","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"52799.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5803349,"started_at":"2020-11-23 11:09:48","seller":"Bloomx","buyer":"CNDYBT","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        11:14:16","completed_at":"2020-11-23 11:14:16","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"EbPCQMiV9mH","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9400.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1020051,"started_at":"2020-11-23 09:31:45","seller":"Bloomx","buyer":"GreatBoobook945","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        09:41:30","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"RrJo1J7XJLd","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9400.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1020280,"started_at":"2020-11-23 09:13:14","seller":"Bloomx","buyer":"GreatBoobook945","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        09:22:34","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"q3LL6xFwGfP","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"11000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1217068,"started_at":"2020-11-23 08:52:41","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        08:56:12","completed_at":"2020-11-23 08:56:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"FoMfNDkxV9F","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4985.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":554960,"started_at":"2020-11-23 08:05:15","seller":"Bloomx","buyer":"Aquinas53","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        08:35:17","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"rXqjizg6fhE","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"39000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":4307931,"started_at":"2020-11-23 08:31:56","seller":"Bloomx","buyer":"Jasonkhomyn","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        08:33:10","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"i6pXA4UF4pz","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2217096,"started_at":"2020-11-23 08:21:58","seller":"Bloomx","buyer":"msnz","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        08:29:57","completed_at":"2020-11-23 08:29:57","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"2hiufcvSbrh","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":222234,"started_at":"2020-11-23 07:24:32","seller":"Bloomx","buyer":"Ramispo2020","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        08:14:23","completed_at":"2020-11-23 08:14:23","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"omK6EntAg7S","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"29800.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":3319257,"started_at":"2020-11-23 07:44:57","seller":"Bloomx","buyer":"Coinspot70","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        08:13:43","completed_at":"2020-11-23 08:13:43","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"ZUSwQX5BHUr","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"8985.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1000264,"started_at":"2020-11-23 08:03:26","seller":"Bloomx","buyer":"Aquinas53","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        08:04:08","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"5kCxgvgEiM8","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2227689,"started_at":"2020-11-23 07:43:54","seller":"Bloomx","buyer":"Benlet0428","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        07:46:19","completed_at":"2020-11-23 07:46:19","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"9jg4NxWhcnY","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6800.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":759380,"started_at":"2020-11-23 06:53:46","seller":"Bloomx","buyer":"JayS3333","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        07:02:23","completed_at":"2020-11-23 07:02:23","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"Lxx8XmPyvE8","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":223945,"started_at":"2020-11-23 06:22:52","seller":"Bloomx","buyer":"lynindkk","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        06:53:57","completed_at":"2020-11-23 06:53:57","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"X1EN5meWfBr","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2350.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":261525,"started_at":"2020-11-23 05:59:38","seller":"Bloomx","buyer":"lynindkk","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        06:53:15","completed_at":"2020-11-23 06:53:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"aMswduNDyTV","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"35000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":3923354,"started_at":"2020-11-23 06:39:30","seller":"Bloomx","buyer":"Shee_Gat","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        06:45:13","completed_at":"2020-11-23 06:45:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"ifFGcdqqHes","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"50000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5604792,"started_at":"2020-11-23 06:34:20","seller":"Bloomx","buyer":"Shee_Gat","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        06:39:12","completed_at":"2020-11-23 06:39:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"BKXbXNwgrsq","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2350.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":261872,"started_at":"2020-11-23 04:46:56","seller":"Bloomx","buyer":"lynindkk","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        05:16:57","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"eZznu2H7LUc","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1111177,"started_at":"2020-11-23 04:39:15","seller":"Bloomx","buyer":"Jadetm","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        05:09:18","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"y2LcpmyrG3U","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1115305,"started_at":"2020-11-23 04:02:28","seller":"Bloomx","buyer":"Jadetm","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        04:32:30","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"FnbkRroeq9r","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"199999.86","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":22351217,"started_at":"2020-11-23 03:37:09","seller":"Bloomx","buyer":"Himatraders","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        03:40:49","completed_at":"2020-11-23 03:40:49","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"2dBUPezt7D5","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2243538,"started_at":"2020-11-23 02:25:16","seller":"Bloomx","buyer":"Betterpekin3255","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        02:33:20","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"5gH5sUTtkj8","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":339631,"started_at":"2020-11-23 01:03:14","seller":"Bloomx","buyer":"HumaneCombfish556","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        01:16:42","completed_at":"2020-11-23 01:16:42","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"GpR8krVrtQB","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"1950.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":219043,"started_at":"2020-11-23 00:46:32","seller":"Bloomx","buyer":"LeCoinJames","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        01:16:33","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"dtXhxXWfvfT","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1682937,"started_at":"2020-11-23 00:31:15","seller":"Bloomx","buyer":"Benlet0428","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        00:33:17","completed_at":"2020-11-23 00:33:17","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"sheNAn5uqc1","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2255.27","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":250000,"started_at":"2020-11-22 23:47:26","seller":"Bloomx","buyer":"cryptoladie","fiat_currency_code":"PHP","ended_at":"2020-11-23
-        00:00:36","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"Yi8rih7SBtz","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":441776,"started_at":"2020-11-22 21:57:15","seller":"Bloomx","buyer":"angelarachelbee","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        21:59:13","completed_at":"2020-11-22 21:59:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"S1UQcEystWS","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5600.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":618486,"started_at":"2020-11-22 21:53:28","seller":"Bloomx","buyer":"angelarachelbee","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        21:55:17","completed_at":"2020-11-22 21:55:17","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"}]}}'
-    http_version:
-  recorded_at: Wed, 25 Nov 2020 08:48:13 GMT
+      string: '{"status":"success","timestamp":1608024601,"data":{"count":100,"page":1,"trades":[{"trade_hash":"4xrfLwzBMLF","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2600.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":279324,"started_at":"2020-12-15 08:00:59","seller":"Bloomx","buyer":"Laminar","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        08:31:01","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"xEocVtf2TLZ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"1999.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":215167,"started_at":"2020-12-15 07:01:07","seller":"Bloomx","buyer":"CNDYBT","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        07:03:25","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"L1n64RYtsf1","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2652.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":286941,"started_at":"2020-12-15 05:23:48","seller":"Bloomx","buyer":"Laminar","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        05:34:42","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"JSCmoUWggUH","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"200000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":21474515,"started_at":"2020-12-15 05:08:39","seller":"Bloomx","buyer":"Tcd999","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        05:29:27","completed_at":"2020-12-15 05:29:27","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"tRoiriJBGzf","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"470000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":50107208,"started_at":"2020-12-15 04:51:18","seller":"Bloomx","buyer":"Tcd999","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        05:07:12","completed_at":"2020-12-15 05:07:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"zvC6xfGUF7s","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"300000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":31823889,"started_at":"2020-12-15 03:06:34","seller":"Bloomx","buyer":"luponwxc","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        04:09:24","completed_at":"2020-12-15 04:09:24","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"AV8WJAFjapJ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9700.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1028235,"started_at":"2020-12-15 03:11:05","seller":"Bloomx","buyer":"Lovelyjoy1969","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        03:18:27","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"xWDhijzkggG","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9700.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1025650,"started_at":"2020-12-15 02:51:37","seller":"Bloomx","buyer":"Lovelyjoy1969","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        03:02:38","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"RTnXdr8gqtV","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9700.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1023933,"started_at":"2020-12-15 02:12:02","seller":"Bloomx","buyer":"Lovelyjoy1969","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        02:42:03","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"LeMsFhzuHae","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"35000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":3736510,"started_at":"2020-12-15 01:26:21","seller":"Bloomx","buyer":"SabAggabao05","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        01:29:14","completed_at":"2020-12-15 01:29:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"iqjpVZACpUW","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9700.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1037321,"started_at":"2020-12-15 00:31:04","seller":"Bloomx","buyer":"Lovelyjoy1969","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        00:43:30","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"xg51oSrWAzC","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6900.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":737888,"started_at":"2020-12-15 00:37:05","seller":"Bloomx","buyer":"angelarachelbee","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        00:40:16","completed_at":"2020-12-15 00:40:16","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"Rcsqr3vZJiH","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"50000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":5361143,"started_at":"2020-12-15 00:19:30","seller":"Bloomx","buyer":"irfanvural","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        00:20:31","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"Z3dn83LkgNi","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7450.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":798810,"started_at":"2020-12-15 00:16:19","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        00:20:20","completed_at":"2020-12-15 00:20:20","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"mcWdW1rSuSR","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":214149,"started_at":"2020-12-14 23:56:47","seller":"Bloomx","buyer":"jpmcrypto","fiat_currency_code":"PHP","ended_at":"2020-12-15
+        00:14:14","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"4bXndiy9Y2Q","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"13000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1397723,"started_at":"2020-12-14 15:08:10","seller":"Bloomx","buyer":"ElleWins","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        15:09:26","completed_at":"2020-12-14 15:09:26","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"ewPcWVrEHQf","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"250000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":26922286,"started_at":"2020-12-14 13:52:11","seller":"Bloomx","buyer":"luponwxc","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        13:52:25","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"EjrnqUUAVbr","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":377334,"started_at":"2020-12-14 13:42:12","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        13:45:24","completed_at":"2020-12-14 13:45:24","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"5gthuKW4ibV","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"21450.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2319866,"started_at":"2020-12-14 13:11:13","seller":"Bloomx","buyer":"MangMario","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        13:28:26","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"rzXsi37mnUV","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3250.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":351677,"started_at":"2020-12-14 13:21:05","seller":"Bloomx","buyer":"cryptoladie","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        13:21:34","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"Db3ViJrYcoC","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":594795,"started_at":"2020-12-14 12:58:50","seller":"Bloomx","buyer":"Destin1","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        13:01:02","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"9eLjAHMibwk","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"300000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":32455066,"started_at":"2020-12-14 11:52:33","seller":"Bloomx","buyer":"luponwxc","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        12:22:37","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"9Uxjgap5Twt","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":594217,"started_at":"2020-12-14 12:08:12","seller":"Bloomx","buyer":"Destin1","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        12:22:20","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"dNTdd7Rf4iw","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":595010,"started_at":"2020-12-14 12:00:01","seller":"Bloomx","buyer":"Destin1","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        12:01:51","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"JxXdMCcakHB","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2700.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":292371,"started_at":"2020-12-14 11:10:48","seller":"Bloomx","buyer":"iamDMC","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        11:28:31","completed_at":"2020-12-14 11:28:31","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"chS5ynrsqE2","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"75000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":8104767,"started_at":"2020-12-14 10:52:40","seller":"Bloomx","buyer":"Markhy969","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        11:27:40","completed_at":"2020-12-14 11:27:40","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"8U8QkchVT8A","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"13500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1453717,"started_at":"2020-12-14 10:33:28","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        11:03:29","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"9JTDofW1HXf","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"480000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":51700252,"started_at":"2020-12-14 10:35:45","seller":"Bloomx","buyer":"Markhy969","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        10:42:42","completed_at":"2020-12-14 10:42:42","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"3VmJXnc5V3v","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"40000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":4299761,"started_at":"2020-12-14 10:19:44","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        10:33:11","completed_at":"2020-12-14 10:33:11","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"bybSMiJajkv","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20100.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2166880,"started_at":"2020-12-14 10:26:47","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        10:32:44","completed_at":"2020-12-14 10:32:44","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"kX86UMx6zvH","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"31800.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":3415614,"started_at":"2020-12-14 09:18:02","seller":"Bloomx","buyer":"henriex","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        09:19:14","completed_at":"2020-12-14 09:19:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"14NTwRae1hb","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2700.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":289717,"started_at":"2020-12-14 09:09:14","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        09:12:14","completed_at":"2020-12-14 09:12:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"sVqMfYpEged","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"8500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":912072,"started_at":"2020-12-14 09:08:10","seller":"Bloomx","buyer":"Rayray777","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        09:08:20","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"dfx2T9L6JJc","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"8500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":912072,"started_at":"2020-12-14 09:00:38","seller":"Bloomx","buyer":"Rayray777","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        09:07:35","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"dUgYx5MVZB3","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"80000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":8604580,"started_at":"2020-12-14 08:52:36","seller":"Bloomx","buyer":"BtcPhil","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        09:02:00","completed_at":"2020-12-14 09:02:00","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"BEoxSrTbRvH","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2322.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":249860,"started_at":"2020-12-14 08:34:13","seller":"Bloomx","buyer":"iamDMC","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        08:39:42","completed_at":"2020-12-14 08:39:42","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"4fmqvbzo6y2","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2322.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":249839,"started_at":"2020-12-14 07:58:15","seller":"Bloomx","buyer":"iamDMC","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        08:28:19","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"rwHJv7mxppb","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3300.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":356694,"started_at":"2020-12-14 06:07:04","seller":"Bloomx","buyer":"Marialouis","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        08:01:10","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"TXgWmVyd3nG","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"64999.99","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":6998195,"started_at":"2020-12-14 07:34:12","seller":"Bloomx","buyer":"XJun","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        07:57:09","completed_at":"2020-12-14 07:57:09","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"m3cQGos2Puy","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"64999.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":6998088,"started_at":"2020-12-14 07:33:00","seller":"Bloomx","buyer":"XJun","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        07:34:01","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"ftkqV2ZJaLA","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"65000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":7021066,"started_at":"2020-12-14 07:26:40","seller":"Bloomx","buyer":"XJun","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        07:32:44","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"hcSY7gTM3uC","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"8100.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":872942,"started_at":"2020-12-14 06:18:16","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        07:30:30","completed_at":"2020-12-14 07:30:30","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"BKTdvFJhSSi","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3300.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":356694,"started_at":"2020-12-14 06:00:24","seller":"Bloomx","buyer":"Marialouis","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        06:50:50","completed_at":"2020-12-14 06:50:50","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"bdZb7wi8DQH","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1080844,"started_at":"2020-12-14 05:53:15","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        06:50:28","completed_at":"2020-12-14 06:50:28","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"BzqtdT4iCPR","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"35000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":3775862,"started_at":"2020-12-14 06:43:55","seller":"Bloomx","buyer":"SabAggabao05","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        06:48:36","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"XHaYzS9VR8Q","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"100000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":10788178,"started_at":"2020-12-14 06:41:39","seller":"Bloomx","buyer":"Shee_Gat","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        06:47:13","completed_at":"2020-12-14 06:47:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"DiKSKgxtupF","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"50000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":5390681,"started_at":"2020-12-14 06:23:31","seller":"Bloomx","buyer":"SabAggabao05","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        06:39:14","completed_at":"2020-12-14 06:39:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"oieFq3g5vbd","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1616560,"started_at":"2020-12-14 06:16:36","seller":"Bloomx","buyer":"Benlet0428","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        06:26:23","completed_at":"2020-12-14 06:26:23","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"j2ANjrP49dK","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"33600.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":3635827,"started_at":"2020-12-14 05:27:28","seller":"Bloomx","buyer":"WYZZYPAX","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        05:29:13","completed_at":"2020-12-14 05:29:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"GPzYLSrbFgT","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7900.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":852575,"started_at":"2020-12-14 05:15:18","seller":"Bloomx","buyer":"jasperrobin","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        05:23:15","completed_at":"2020-12-14 05:23:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"3xw9KAQiUA9","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"50000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":5361871,"started_at":"2020-12-14 04:29:29","seller":"Bloomx","buyer":"SabAggabao05","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        04:59:33","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"HqK6oQJfZVJ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2162916,"started_at":"2020-12-14 04:36:49","seller":"Bloomx","buyer":"glosky1067","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        04:53:04","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"57vCd6X3FUM","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"18900.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2045612,"started_at":"2020-12-14 04:41:46","seller":"Bloomx","buyer":"Coinspot70","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        04:45:14","completed_at":"2020-12-14 04:45:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"ewyEmjKJfpN","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49998.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":5357828,"started_at":"2020-12-14 04:06:10","seller":"Bloomx","buyer":"ElleWins","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        04:08:13","completed_at":"2020-12-14 04:08:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"MLrNZunHQXG","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"120000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":12858013,"started_at":"2020-12-14 03:53:16","seller":"Bloomx","buyer":"Chris399","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        04:01:37","completed_at":"2020-12-14 04:01:37","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"ZvdM8c5iucY","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"300000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":32090110,"started_at":"2020-12-14 03:25:21","seller":"Bloomx","buyer":"luponwxc","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        03:38:13","completed_at":"2020-12-14 03:38:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"yaPvzrEZQpS","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":214603,"started_at":"2020-12-14 02:54:06","seller":"Bloomx","buyer":"egs_888","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        03:24:07","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"FyqxLsCCjfs","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15444.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1658677,"started_at":"2020-12-14 02:49:13","seller":"Bloomx","buyer":"kalvinpaolo","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        02:51:12","completed_at":"2020-12-14 02:51:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"9sa7Kj4rHhe","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9800.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1059922,"started_at":"2020-12-14 02:07:53","seller":"Bloomx","buyer":"ShowyCepalin","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        02:18:58","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"r432HyjSF9c","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2164261,"started_at":"2020-12-14 01:14:53","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        01:18:12","completed_at":"2020-12-14 01:18:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"5s1NnfbfyMd","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1610898,"started_at":"2020-12-13 23:50:50","seller":"Bloomx","buyer":"BonzerScad362","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        00:20:51","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"gYdV8HR8q8E","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"200000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":21637093,"started_at":"2020-12-14 00:17:52","seller":"Bloomx","buyer":"luponwxc","fiat_currency_code":"PHP","ended_at":"2020-12-14
+        00:18:10","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"MD4JLPMcDmb","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"33400.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":3586934,"started_at":"2020-12-13 23:56:07","seller":"Bloomx","buyer":"WYZZYPAX","fiat_currency_code":"PHP","ended_at":"2020-12-13
+        23:58:14","completed_at":"2020-12-13 23:58:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"YqTMGSmvQyN","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1677685,"started_at":"2020-12-10 09:39:19","seller":"Bloomx","buyer":"SabAggabao05","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        10:09:22","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"BFnAo6TfNxw","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1681612,"started_at":"2020-12-10 09:43:11","seller":"Bloomx","buyer":"SabAggabao05","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        09:44:12","completed_at":"2020-12-10 09:44:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"qQa7mrJMJNK","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2237730,"started_at":"2020-12-10 08:17:05","seller":"Bloomx","buyer":"Gabrielteo2014","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        08:32:22","completed_at":"2020-12-10 08:32:22","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"CrH6fJKttCR","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3950.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":444287,"started_at":"2020-12-10 08:00:42","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        08:03:15","completed_at":"2020-12-10 08:03:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"LSrEiakzxPe","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"11563.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1299444,"started_at":"2020-12-10 07:55:11","seller":"Bloomx","buyer":"kalvinpaolo","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        07:56:13","completed_at":"2020-12-10 07:56:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"xewwoVru7js","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2700.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":303328,"started_at":"2020-12-10 07:49:06","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        07:53:13","completed_at":"2020-12-10 07:53:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"wjGeYpRjWUK","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3150.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":354107,"started_at":"2020-12-10 07:31:02","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        07:33:13","completed_at":"2020-12-10 07:33:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"JMNQemamias","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":560906,"started_at":"2020-12-10 05:37:18","seller":"Bloomx","buyer":"lynindkk","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        07:23:25","completed_at":"2020-12-10 07:23:25","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"6xmLjrYjbZz","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"99999.95","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":11268571,"started_at":"2020-12-10 06:32:36","seller":"Bloomx","buyer":"Gabrielteo2014","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        07:23:08","completed_at":"2020-12-10 07:23:08","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"qsGGiTdXErY","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"8900.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1002903,"started_at":"2020-12-10 06:37:51","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        06:41:12","completed_at":"2020-12-10 06:41:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"cQ4iwQwEUmE","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":336677,"started_at":"2020-12-10 06:06:58","seller":"Bloomx","buyer":"PNG_BTC","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        06:10:25","completed_at":"2020-12-10 06:10:25","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"28CoEitvnkv","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.99","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":5620922,"started_at":"2020-12-10 05:58:10","seller":"Bloomx","buyer":"Gabrielteo2014","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        06:09:47","completed_at":"2020-12-10 06:09:47","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"fWEhsxqxWeJ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":559877,"started_at":"2020-12-10 05:28:04","seller":"Bloomx","buyer":"lynindkk","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        05:58:08","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"7e2Q36Jksfo","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.99","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":5609060,"started_at":"2020-12-10 05:34:03","seller":"Bloomx","buyer":"Gabrielteo2014","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        05:57:49","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"cYCMvtZh69k","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":560906,"started_at":"2020-12-10 05:35:32","seller":"Bloomx","buyer":"CharMitchva","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        05:39:24","completed_at":"2020-12-10 05:39:24","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"PrFXjq2Xz11","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":559877,"started_at":"2020-12-10 05:26:15","seller":"Bloomx","buyer":"lynindkk","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        05:37:13","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"1pVGkbEogAj","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"33900.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":3789805,"started_at":"2020-12-10 05:02:16","seller":"Bloomx","buyer":"WYZZYPAX","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        05:04:18","completed_at":"2020-12-10 05:04:18","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"qF4u8yy4ppY","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1118983,"started_at":"2020-12-10 04:19:04","seller":"Bloomx","buyer":"odecendario","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        04:28:06","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"ixgVUyE3L4b","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6300.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":705868,"started_at":"2020-12-10 04:07:14","seller":"Bloomx","buyer":"lcswings","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        04:09:13","completed_at":"2020-12-10 04:09:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"JT5BzxRqfxP","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5100.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":571780,"started_at":"2020-12-10 02:58:08","seller":"Bloomx","buyer":"Raymond211","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        03:28:12","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"eWbFtSyqXsE","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5100.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":571552,"started_at":"2020-12-10 03:00:22","seller":"Bloomx","buyer":"Raymond211","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        03:01:02","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"8HzyK34eavm","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":780821,"started_at":"2020-12-10 02:12:07","seller":"Bloomx","buyer":"SimplyDee","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        02:45:01","completed_at":"2020-12-10 02:45:01","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"1si9PQwq8KC","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"29050.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":3246533,"started_at":"2020-12-10 01:18:57","seller":"Bloomx","buyer":"grceph","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        01:24:36","completed_at":"2020-12-10 01:24:36","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"g1nYLXn6VRr","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":558784,"started_at":"2020-12-10 01:10:22","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-12-10
+        01:13:14","completed_at":"2020-12-10 01:13:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"bQp8t9pk8Dg","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":5421670,"started_at":"2020-12-09 23:39:55","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        23:41:16","completed_at":"2020-12-09 23:41:16","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"7GCvpuY3ffR","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"50000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":5532316,"started_at":"2020-12-09 23:34:16","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        23:38:30","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"5NbNx8M4wi2","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":557409,"started_at":"2020-12-09 21:52:30","seller":"Bloomx","buyer":"CharMitchva","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        21:57:15","completed_at":"2020-12-09 21:57:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"bj2uhyMiLGQ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"18740.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2090477,"started_at":"2020-12-09 21:38:55","seller":"Bloomx","buyer":"angelarachelbee","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        21:44:17","completed_at":"2020-12-09 21:44:17","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"4KxBMqZ8RVz","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"40000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":4494856,"started_at":"2020-12-09 20:28:16","seller":"Bloomx","buyer":"Angeljudes","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        20:58:16","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"Tkbpqwzvp1r","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2025.80","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":229428,"started_at":"2020-12-09 19:05:14","seller":"Bloomx","buyer":"officialshu","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        19:05:32","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"sGgsGBRZs1g","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"18002.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2038789,"started_at":"2020-12-09 19:01:32","seller":"Bloomx","buyer":"ElleWins","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        19:03:14","completed_at":"2020-12-09 19:03:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"VyawrLAe1pj","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1125945,"started_at":"2020-12-09 18:03:17","seller":"Bloomx","buyer":"Coinspot70","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        18:04:11","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"vA96nhsgnAq","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4100.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":460286,"started_at":"2020-12-09 16:59:26","seller":"Bloomx","buyer":"jasperrobin","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        17:02:19","completed_at":"2020-12-09 17:02:19","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"duvyaEhoVR2","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4100.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":460214,"started_at":"2020-12-09 16:00:52","seller":"Bloomx","buyer":"jasperrobin","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        16:30:54","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"wZ4xaKHW1br","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6359.37","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":714404,"started_at":"2020-12-09 15:35:54","seller":"Bloomx","buyer":"lcswings","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        15:38:16","completed_at":"2020-12-09 15:38:16","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"Xb2XEeAjHRp","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":226648,"started_at":"2020-12-09 13:37:15","seller":"Bloomx","buyer":"HotEscolar885","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        13:37:56","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"4y5sQwVStcu","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"100000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":11295878,"started_at":"2020-12-09 13:06:17","seller":"Bloomx","buyer":"walletshores","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        13:36:19","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"}]}}'
+    http_version: 
+  recorded_at: Tue, 15 Dec 2020 09:30:01 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Get_completed_trades/supports_passing_in_a_page_param.yml
+++ b/spec/fixtures/vcr_cassettes/Get_completed_trades/supports_passing_in_a_page_param.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "[host]/trade/completed"
     body:
       encoding: UTF-8
-      string: apikey=[key]&nonce=1606294093&page=2&apiseal=66fdad177b2c1e73f34bca62c6d110b5f7c3d0f9c69ad2c5dac4d512a276566b
+      string: apikey=[key]&nonce=1608024602&page=2&apiseal=0f31f2e4f9598af74063e5c8899b50f3b17268386f0fcb92cb9c48cfadc1d2b9
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus
@@ -21,29 +21,27 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 25 Nov 2020 08:48:13 GMT
+      - Tue, 15 Dec 2020 09:30:02 GMT
       Content-Type:
       - application/json
       Set-Cookie:
-      - __cf_bm=549dbab0891e13df5746166555e6207c8eda2eb8-1606294093-1800-Ac7/eCzTlkNTXqAr+T1rKodLoKxkLUzwm2RtgoSikjMcYj12UVwuYCwgHjfEJrrE/RngnaQusaAK3hAhW5DvO6Q=;
-        path=/; expires=Wed, 25-Nov-20 09:18:13 GMT; domain=.paxful.com; HttpOnly;
+      - __cf_bm=b97f2dfd3d14a36ac9cd4d2921366911911f0c98-1608024602-1800-AfgA6sCEwQquUg3VBCob1py+qacH447e+s7Qt1gSqIPQD0j6317aqLXdkP/jgnWBsmFm48rVUJZahjpLVXl8ves=;
+        path=/; expires=Tue, 15-Dec-20 10:00:02 GMT; domain=.paxful.com; HttpOnly;
         Secure; SameSite=None
-      - __cfduid=dbd7966b3b10b96748e1db3de06bff9961606294093; expires=Fri, 25-Dec-20
-        08:48:13 GMT; path=/; domain=.paxful.com; HttpOnly; SameSite=Lax
-      - __cflb=02DiuJc4sPDmgGhTNdPy7cZ2sNmKt1vEdzvchJ4qPT2vp; SameSite=Lax; path=/;
-        expires=Thu, 26-Nov-20 07:48:13 GMT; HttpOnly
+      - __cfduid=dbef3502c9eb534a20e9368e1f68d89d11608024602; expires=Thu, 14-Jan-21
+        09:30:02 GMT; path=/; domain=.paxful.com; HttpOnly; SameSite=Lax
+      - __cflb=02DiuJc4sPDmgGhTNdPAoBuf263XWhoXuKotTPcrRJNVr; SameSite=Lax; path=/;
+        expires=Wed, 16-Dec-20 08:30:02 GMT; HttpOnly
       Cf-Ray:
-      - 5f7a1c021a4160fa-MNL
+      - 601f24c33be4058d-LAX
       Cache-Control:
       - no-cache, private
       Cf-Cache-Status:
       - DYNAMIC
       Cf-Request-Id:
-      - 06a02fd550000060fa3ba63000000001
+      - 0707554e020000058dd32c4000000001
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      X-Castle-User-Id:
-      - 8b2805fa-fd69-4d15-9115-66a68a48bebe
       X-External-User-Id:
       - 8b2805fa-fd69-4d15-9115-66a68a48bebe
       X-Frame-Options:
@@ -51,214 +49,214 @@ http_interactions:
       X-Ratelimit-Limit:
       - '1000'
       X-Ratelimit-Remaining:
-      - '746'
+      - '769'
       X-User-Id:
       - '2919548'
       Server:
       - cloudflare
     body:
       encoding: UTF-8
-      string: '{"status":"success","timestamp":1606294093,"data":{"count":100,"page":2,"trades":[{"trade_hash":"13FwS4e2otA","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2226010,"started_at":"2020-11-22 16:36:10","seller":"Bloomx","buyer":"Betterpekin3255","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        17:06:11","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"BF8hqWjVCG2","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1669508,"started_at":"2020-11-22 16:35:57","seller":"Bloomx","buyer":"emmanuelnaji","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        17:05:59","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"t2sYooRTdAw","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5980.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":664579,"started_at":"2020-11-22 16:43:07","seller":"Bloomx","buyer":"BITCOINFIRE","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        16:46:14","completed_at":"2020-11-22 16:46:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"ohn1Xb5EJuC","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"11000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1231551,"started_at":"2020-11-22 16:18:45","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        16:21:12","completed_at":"2020-11-22 16:21:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"UURipHTmZ8n","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":563114,"started_at":"2020-11-22 15:31:16","seller":"Bloomx","buyer":"OnwardCroaker841","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        16:01:20","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"Mt6M9TnaFqK","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"180000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":20199961,"started_at":"2020-11-22 15:49:14","seller":"Bloomx","buyer":"luponwxc","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        15:50:58","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"Co6xmFuPnuj","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"120000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":13514747,"started_at":"2020-11-22 15:39:06","seller":"Bloomx","buyer":"kingb12","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        15:42:14","completed_at":"2020-11-22 15:42:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"uJzdQKXnRtz","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6200.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":697106,"started_at":"2020-11-22 15:28:23","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        15:31:15","completed_at":"2020-11-22 15:31:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"hsz6akVe8ba","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5100.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":573426,"started_at":"2020-11-22 15:24:55","seller":"Bloomx","buyer":"Rein12","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        15:26:06","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"YZqjzwPxiYD","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7500.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":846055,"started_at":"2020-11-22 15:05:41","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        15:09:15","completed_at":"2020-11-22 15:09:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"k7jwbuqE6L4","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"100000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":11244109,"started_at":"2020-11-22 14:28:40","seller":"Bloomx","buyer":"bitcoinmasterseller","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        14:58:42","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"hzWrJ5xzW8G","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"22000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2480485,"started_at":"2020-11-22 13:52:32","seller":"Bloomx","buyer":"BTCVPhilippines","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        13:53:28","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"soxLgbDHCVF","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"1950.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":219645,"started_at":"2020-11-22 13:47:34","seller":"Bloomx","buyer":"PlushScoter191","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        13:49:29","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"xM1FfoFqanK","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1135304,"started_at":"2020-11-22 13:02:24","seller":"Bloomx","buyer":"Jadetm","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        13:32:29","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"yRuwseb5Hiz","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"13000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1502565,"started_at":"2020-11-22 12:04:40","seller":"Bloomx","buyer":"mikoangelo","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        12:09:35","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"xxc9Mfaa8vB","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":346746,"started_at":"2020-11-22 12:07:29","seller":"Bloomx","buyer":"MangMario","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        12:09:29","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"EukutNSPXFx","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"23000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2650543,"started_at":"2020-11-22 11:56:23","seller":"Bloomx","buyer":"jcdima10","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        11:57:31","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"5zyoEYa5NPo","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"23000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2641181,"started_at":"2020-11-22 11:46:22","seller":"Bloomx","buyer":"jcdima10","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        11:47:27","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"R9TZWxNkoLD","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2286114,"started_at":"2020-11-22 11:35:22","seller":"Bloomx","buyer":"Benlet0428","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        11:42:16","completed_at":"2020-11-22 11:42:16","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"MgC1nAjAJGB","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1128158,"started_at":"2020-11-22 10:52:32","seller":"Bloomx","buyer":"HeroicWoodhen547","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        11:22:36","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"CXcXMURZYdj","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"8400.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":937267,"started_at":"2020-11-22 09:54:03","seller":"Bloomx","buyer":"user07b99dc06","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        10:24:07","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"JPqD3UXwpp8","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"60000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":6732982,"started_at":"2020-11-22 10:13:43","seller":"Bloomx","buyer":"wheegyb","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        10:16:13","completed_at":"2020-11-22 10:16:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"aDFMWCm8rsu","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"13000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1462868,"started_at":"2020-11-22 09:34:47","seller":"Bloomx","buyer":"mikoangelo","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        10:04:48","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"uptpk2pSstp","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"61499.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":6893111,"started_at":"2020-11-22 09:27:36","seller":"Bloomx","buyer":"CNDYBT","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        09:31:18","completed_at":"2020-11-22 09:31:18","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"xrn5PEhfENf","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6600.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":739892,"started_at":"2020-11-22 09:17:27","seller":"Bloomx","buyer":"JayS3333","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        09:20:18","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"2edyi4sUjzb","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"14000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1569467,"started_at":"2020-11-22 09:11:26","seller":"Bloomx","buyer":"Mazeee6","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        09:14:47","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"q1XTJu9p5tY","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":336314,"started_at":"2020-11-22 09:12:55","seller":"Bloomx","buyer":"HumaneCombfish556","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        09:14:12","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"FsmJ1gyqBam","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"150000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":16752284,"started_at":"2020-11-22 08:42:08","seller":"Bloomx","buyer":"bitcoinmasterseller","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        09:12:11","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"iPbw4dFQW5q","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"13000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1445602,"started_at":"2020-11-22 08:19:24","seller":"Bloomx","buyer":"mikoangelo","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        08:27:30","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"Pe4zi6bmsK8","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1112002,"started_at":"2020-11-22 08:16:45","seller":"Bloomx","buyer":"Benlet0428","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        08:19:15","completed_at":"2020-11-22 08:19:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"U9QFfzq63BT","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"13000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1445967,"started_at":"2020-11-22 07:56:27","seller":"Bloomx","buyer":"mikoangelo","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        07:57:45","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"5Z3eKJDifME","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"50000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5558405,"started_at":"2020-11-22 07:07:06","seller":"Bloomx","buyer":"Nerraw","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        07:37:07","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"kmAwxThXTCv","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"18000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2005339,"started_at":"2020-11-22 07:21:59","seller":"Bloomx","buyer":"jcdima10","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        07:22:42","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"NEFZEoZKF7S","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"50000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5548365,"started_at":"2020-11-22 06:46:40","seller":"Bloomx","buyer":"Nerraw","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        07:19:05","completed_at":"2020-11-22 07:19:05","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"vgEpQR1dWBf","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":555700,"started_at":"2020-11-22 04:28:20","seller":"Bloomx","buyer":"TiptopZiege735","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        07:18:35","completed_at":"2020-11-22 07:18:35","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"xjUkgt1iE5W","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4020.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":444923,"started_at":"2020-11-22 03:58:15","seller":"Bloomx","buyer":"CaptainSushi06","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        07:18:21","completed_at":"2020-11-22 07:18:21","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"3G48rHeREsv","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2213546,"started_at":"2020-11-22 03:58:38","seller":"Bloomx","buyer":"Pitaks","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        07:18:13","completed_at":"2020-11-22 07:18:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"MSBv8Nndrve","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"12000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1327084,"started_at":"2020-11-22 04:07:51","seller":"Bloomx","buyer":"lynindkk","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        07:18:05","completed_at":"2020-11-22 07:18:05","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"v4ow98expnu","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6500.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":722963,"started_at":"2020-11-22 06:32:49","seller":"Bloomx","buyer":"Amrelgertan","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        06:50:42","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"ns3dgbiw2ue","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":331886,"started_at":"2020-11-22 05:39:12","seller":"Bloomx","buyer":"Crypto4chun","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        06:09:15","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"SWn6W7hbEoC","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1109177,"started_at":"2020-11-22 05:51:27","seller":"Bloomx","buyer":"Mayie","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        05:52:50","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"XFK2J8s1ViL","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":331569,"started_at":"2020-11-22 05:07:57","seller":"Bloomx","buyer":"Crypto4chun","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        05:38:00","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"bucc5iLzyp8","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":331585,"started_at":"2020-11-22 04:59:41","seller":"Bloomx","buyer":"Amrelgertan","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        05:29:42","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"LRWpeCVXt8L","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"18000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1989413,"started_at":"2020-11-22 05:01:40","seller":"Bloomx","buyer":"Coinspot70","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        05:07:07","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"y7tcLdffDXu","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"29500.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":3263663,"started_at":"2020-11-22 04:48:47","seller":"Bloomx","buyer":"Coinspot70","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        05:06:57","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"f1Z1maay5zK","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4985.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":552880,"started_at":"2020-11-22 04:18:16","seller":"Bloomx","buyer":"Aquinas53","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        04:48:18","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"Y3kG1NQqR7v","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2500.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":272243,"started_at":"2020-11-21 16:23:17","seller":"Bloomx","buyer":"Amrelgertan","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        04:38:46","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"9BaJESEzw2K","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":222280,"started_at":"2020-11-22 04:25:33","seller":"Bloomx","buyer":"Erwin81","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        04:25:51","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"Ko3SsqKFbHn","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4985.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":552770,"started_at":"2020-11-22 03:43:26","seller":"Bloomx","buyer":"Aquinas53","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        04:13:27","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"GjzE14NbrsJ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"40000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":4449726,"started_at":"2020-11-22 02:09:24","seller":"Bloomx","buyer":"BonzerPilchard450","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        02:28:13","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"Y5BDKoywdTg","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"25000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2781079,"started_at":"2020-11-22 02:04:42","seller":"Bloomx","buyer":"jcdima10","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        02:10:40","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"MQf5MUCgqqi","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"25000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2766664,"started_at":"2020-11-22 01:02:52","seller":"Bloomx","buyer":"jcdima10","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        01:26:18","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"4kU6oyLCpSi","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":552101,"started_at":"2020-11-22 01:18:06","seller":"Bloomx","buyer":"CharMitchva","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        01:20:12","completed_at":"2020-11-22 01:20:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"vzQv4LbbXUa","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1104202,"started_at":"2020-11-22 01:16:32","seller":"Bloomx","buyer":"CharMitchva","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        01:17:59","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"Mjph4Ynhemx","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"40000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":4394003,"started_at":"2020-11-22 00:42:26","seller":"Bloomx","buyer":"BonzerPilchard450","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        01:12:30","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"QUujonrHTCy","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"25000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2739543,"started_at":"2020-11-22 00:20:50","seller":"Bloomx","buyer":"jcdima10","fiat_currency_code":"PHP","ended_at":"2020-11-22
-        00:21:45","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"sbj2MDDgcGr","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1099679,"started_at":"2020-11-21 23:30:47","seller":"Bloomx","buyer":"lcswings","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        23:33:15","completed_at":"2020-11-21 23:33:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"gitxQj1hiMe","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2191313,"started_at":"2020-11-21 17:17:41","seller":"Bloomx","buyer":"LawfulEland65","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        17:18:32","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"YBcCgR3yB9q","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"200000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":21839059,"started_at":"2020-11-21 16:02:39","seller":"Bloomx","buyer":"cairoman63","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        16:32:42","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"66cwADdfMx7","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"50000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5494632,"started_at":"2020-11-21 15:18:25","seller":"Bloomx","buyer":"AvidBurbot88","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        15:20:06","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"5Kvt6Smqt1S","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"50000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5486531,"started_at":"2020-11-21 14:49:07","seller":"Bloomx","buyer":"AvidBurbot88","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        14:49:33","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"bSr9wiGA93d","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"48399.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5298345,"started_at":"2020-11-21 14:29:39","seller":"Bloomx","buyer":"CNDYBT","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        14:34:12","completed_at":"2020-11-21 14:34:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"4fXqgXyjYaL","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"25000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2733544,"started_at":"2020-11-21 13:56:20","seller":"Bloomx","buyer":"lynindkk","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        14:26:22","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"g9tQcBsuGke","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"30000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":3280253,"started_at":"2020-11-21 13:59:31","seller":"Bloomx","buyer":"SuperARK","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        14:01:55","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"YDMH73zNw48","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"250000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":27476485,"started_at":"2020-11-21 13:39:36","seller":"Bloomx","buyer":"luponwxc","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        13:40:32","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"M2VgeodgENe","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":660050,"started_at":"2020-11-21 13:27:13","seller":"Bloomx","buyer":"escorpi","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        13:30:12","completed_at":"2020-11-21 13:30:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"jjJuoytpjht","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":439619,"started_at":"2020-11-21 13:11:59","seller":"Bloomx","buyer":"CaptainSushi06","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        13:12:32","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"6sMdm1mFZ3m","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4985.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":548199,"started_at":"2020-11-21 10:17:40","seller":"Bloomx","buyer":"Aquinas53","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        10:23:05","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"JqpX5JWDssE","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4985.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":548199,"started_at":"2020-11-21 10:12:47","seller":"Bloomx","buyer":"Aquinas53","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        10:15:03","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"tNwbH8FthKz","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"50000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5513837,"started_at":"2020-11-21 10:06:49","seller":"Bloomx","buyer":"kingb12","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        10:12:12","completed_at":"2020-11-21 10:12:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"Et9NnKJrEkc","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9500.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1047629,"started_at":"2020-11-21 10:02:58","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        10:05:12","completed_at":"2020-11-21 10:05:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"hwqXybHy7yq","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9400.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1011881,"started_at":"2020-11-21 09:27:38","seller":"Bloomx","buyer":"GreatBoobook945","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        09:57:39","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"wyNdD6eaSQJ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2211020,"started_at":"2020-11-21 09:44:06","seller":"Bloomx","buyer":"Benlet0428","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        09:47:13","completed_at":"2020-11-21 09:47:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"WSfKvopGeE2","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9400.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1012610,"started_at":"2020-11-21 09:35:41","seller":"Bloomx","buyer":"GreatBoobook945","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        09:37:25","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"fvutPkgmTAg","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"30000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":3295313,"started_at":"2020-11-21 09:24:11","seller":"Bloomx","buyer":"ElleWins","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        09:28:23","completed_at":"2020-11-21 09:28:23","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"ZGtRPbFvSjj","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6840.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":751331,"started_at":"2020-11-21 09:25:50","seller":"Bloomx","buyer":"BITCOINFIRE","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        09:28:12","completed_at":"2020-11-21 09:28:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"4mCg7XiJkc6","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":329142,"started_at":"2020-11-21 08:46:46","seller":"Bloomx","buyer":"HeroicWoodhen547","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        09:16:48","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"wivdoDAuhX1","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"28000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":3074841,"started_at":"2020-11-21 06:33:12","seller":"Bloomx","buyer":"Coinspot70","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        08:47:26","completed_at":"2020-11-21 08:47:26","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"i15rKy2dYRt","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3300.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":363767,"started_at":"2020-11-21 07:12:14","seller":"Bloomx","buyer":"Kimoooooooo","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        08:46:35","completed_at":"2020-11-21 08:46:35","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"ymetqxZ4xj6","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6500.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":713802,"started_at":"2020-11-21 06:33:36","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        06:39:14","completed_at":"2020-11-21 06:39:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"pCK6tKPHZz5","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"8500.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":936102,"started_at":"2020-11-21 06:02:53","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        06:05:17","completed_at":"2020-11-21 06:05:17","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"S56vuPEuWYu","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1106064,"started_at":"2020-11-21 04:49:03","seller":"Bloomx","buyer":"CharMitchva","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        04:53:14","completed_at":"2020-11-21 04:53:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"6SA9uK4fF1M","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":549731,"started_at":"2020-11-21 03:53:27","seller":"Bloomx","buyer":"TiptopZiege735","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        04:28:54","completed_at":"2020-11-21 04:28:54","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"Nr3Ut1MFDyN","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.99","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5459096,"started_at":"2020-11-21 03:20:25","seller":"Bloomx","buyer":"HeartyKite67","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        03:37:05","completed_at":"2020-11-21 03:37:05","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"DdsKwmeu4zf","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.98","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5470953,"started_at":"2020-11-21 03:12:27","seller":"Bloomx","buyer":"Himatraders","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        03:20:11","completed_at":"2020-11-21 03:20:11","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"chgn392CrnT","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5470845,"started_at":"2020-11-21 03:12:08","seller":"Bloomx","buyer":"XJun","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        03:20:03","completed_at":"2020-11-21 03:20:03","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"gqzewJGnwjN","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2184374,"started_at":"2020-11-21 02:51:04","seller":"Bloomx","buyer":"Benlet0428","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        02:53:15","completed_at":"2020-11-21 02:53:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"PLD3axudyPw","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":2177943,"started_at":"2020-11-21 02:00:51","seller":"Bloomx","buyer":"Pitaks","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        02:47:21","completed_at":"2020-11-21 02:47:21","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"fnfVHecj2s2","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6700.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":726263,"started_at":"2020-11-21 02:25:40","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        02:29:13","completed_at":"2020-11-21 02:29:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"7nfZyszVbFa","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"13000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1415663,"started_at":"2020-11-21 02:05:07","seller":"Bloomx","buyer":"lcswings","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        02:07:13","completed_at":"2020-11-21 02:07:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"S2DDj5uaWtN","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1632235,"started_at":"2020-11-21 01:32:26","seller":"Bloomx","buyer":"angelarachelbee","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        01:34:14","completed_at":"2020-11-21 01:34:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"CGtdAV6UZiH","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":762807,"started_at":"2020-11-21 01:29:29","seller":"Bloomx","buyer":"CharloneB","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        01:32:12","completed_at":"2020-11-21 01:32:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"uLbTYd8Ybty","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3900.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":428792,"started_at":"2020-11-21 00:27:23","seller":"Bloomx","buyer":"PNG_BTC","fiat_currency_code":"PHP","ended_at":"2020-11-21
-        00:31:04","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"jXtGj2YNnwh","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":551648,"started_at":"2020-11-20 23:26:14","seller":"Bloomx","buyer":"CharMitchva","fiat_currency_code":"PHP","ended_at":"2020-11-20
-        23:34:15","completed_at":"2020-11-20 23:34:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"4EvuCpHRxrZ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":554584,"started_at":"2020-11-20 22:21:41","seller":"Bloomx","buyer":"TiptopZiege735","fiat_currency_code":"PHP","ended_at":"2020-11-20
-        22:22:27","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"7KKsQ1K38vT","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"16100.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":1777735,"started_at":"2020-11-20 21:42:06","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-11-20
-        21:44:18","completed_at":"2020-11-20 21:44:18","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"nYZrJXwat5J","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":218684,"started_at":"2020-11-20 16:32:55","seller":"Bloomx","buyer":"wijo","fiat_currency_code":"PHP","ended_at":"2020-11-20
-        17:02:56","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"YoCtvJ24iZW","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"50000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":5494175,"started_at":"2020-11-20 16:02:01","seller":"Bloomx","buyer":"kingb12","fiat_currency_code":"PHP","ended_at":"2020-11-20
-        16:14:17","completed_at":"2020-11-20 16:14:17","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"uDTYmZnWEPn","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4900.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":549271,"started_at":"2020-11-20 14:20:35","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-11-20
-        14:24:14","completed_at":"2020-11-20 14:24:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"fF21tw4vveq","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"100000.00","payment_method_name":"Bank
-        Transfer","crypto_amount_requested":11267454,"started_at":"2020-11-20 13:49:00","seller":"Bloomx","buyer":"kingb12","fiat_currency_code":"PHP","ended_at":"2020-11-20
-        13:54:17","completed_at":"2020-11-20 13:54:17","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"}]}}'
-    http_version:
-  recorded_at: Wed, 25 Nov 2020 08:48:13 GMT
+      string: '{"status":"success","timestamp":1608024602,"data":{"count":100,"page":2,"trades":[{"trade_hash":"ENiA4HHhiN6","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4200.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":472949,"started_at":"2020-12-09 12:21:12","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        12:51:15","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"9w677ehdtGq","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"29100.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":3287327,"started_at":"2020-12-09 12:06:22","seller":"Bloomx","buyer":"grceph","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        12:36:25","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"cem5QN33Mnf","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":337988,"started_at":"2020-12-09 12:11:47","seller":"Bloomx","buyer":"apryl","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        12:13:15","completed_at":"2020-12-09 12:13:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"mZBedKVgJRq","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1717048,"started_at":"2020-12-09 10:09:58","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        10:30:09","completed_at":"2020-12-09 10:30:09","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"GfzbLKiPmqg","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2700.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":309296,"started_at":"2020-12-09 10:24:57","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        10:28:12","completed_at":"2020-12-09 10:28:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"juD5sXYwWcr","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1154858,"started_at":"2020-12-09 08:55:12","seller":"Bloomx","buyer":"ComelyBrolga125","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        09:25:14","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"4JketrVbRTa","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5100.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":584131,"started_at":"2020-12-09 09:16:26","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        09:22:13","completed_at":"2020-12-09 09:22:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"3c46kCzcA69","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"1950.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":223344,"started_at":"2020-12-09 09:11:10","seller":"Bloomx","buyer":"fresh_Bitoshi","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        09:18:59","completed_at":"2020-12-09 09:18:59","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"iLoGVNpy6jr","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"24285.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2768199,"started_at":"2020-12-09 07:57:56","seller":"Bloomx","buyer":"Maaarkyx","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        08:22:15","completed_at":"2020-12-09 08:22:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"ydqE2jyLs41","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49999.99","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":5679181,"started_at":"2020-12-09 07:42:52","seller":"Bloomx","buyer":"Gabrielteo2014","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        08:08:06","completed_at":"2020-12-09 08:08:06","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"gmL782edMTu","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6359.37","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":724892,"started_at":"2020-12-09 07:55:02","seller":"Bloomx","buyer":"lcswings","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        07:55:27","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"sDLBfmwXLZL","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":850030,"started_at":"2020-12-09 07:15:16","seller":"Bloomx","buyer":"Marialouis","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        07:20:26","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"tNxqCA58seU","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":849803,"started_at":"2020-12-09 05:51:37","seller":"Bloomx","buyer":"Marialouis","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        07:20:03","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"Chqiao2dpv7","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2270458,"started_at":"2020-12-09 06:53:45","seller":"Bloomx","buyer":"Pebz","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        07:18:11","completed_at":"2020-12-09 07:18:11","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"yTriAiXcH2J","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":850064,"started_at":"2020-12-09 07:07:31","seller":"Bloomx","buyer":"Marialouis","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        07:16:25","completed_at":"2020-12-09 07:16:25","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"vkZKxqwRBSr","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":851422,"started_at":"2020-12-09 06:57:24","seller":"Bloomx","buyer":"Marialouis","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        07:01:54","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"1NvjpmhPEev","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":851422,"started_at":"2020-12-09 06:52:49","seller":"Bloomx","buyer":"Marialouis","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        06:57:08","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"wEJ8bLgWjw1","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1132349,"started_at":"2020-12-09 06:32:11","seller":"Bloomx","buyer":"ComelyBrolga125","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        06:55:24","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"qVbgwEjMPee","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2264699,"started_at":"2020-12-09 06:34:07","seller":"Bloomx","buyer":"Pebz","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        06:47:30","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"yRbWfkYaUPp","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":847679,"started_at":"2020-12-09 06:09:07","seller":"Bloomx","buyer":"Marialouis","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        06:12:26","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"rFj82qse1tS","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":847679,"started_at":"2020-12-09 06:02:46","seller":"Bloomx","buyer":"Marialouis","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        06:08:53","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"gehKVWyb4fG","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2700.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":305836,"started_at":"2020-12-09 05:10:35","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        05:14:11","completed_at":"2020-12-09 05:14:11","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"o3iw2cPw3NN","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"25000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2815007,"started_at":"2020-12-09 03:03:39","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        03:13:58","completed_at":"2020-12-09 03:13:58","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"QpV8ejdphiX","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3479.25","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":391764,"started_at":"2020-12-09 03:07:37","seller":"Bloomx","buyer":"lcswings","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        03:11:14","completed_at":"2020-12-09 03:11:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"3C2Sg9hDV2r","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3479.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":391736,"started_at":"2020-12-09 03:07:22","seller":"Bloomx","buyer":"lcswings","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        03:07:29","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"tkDwVRwL2Fy","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"46000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":5176638,"started_at":"2020-12-09 02:56:17","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        03:05:31","completed_at":"2020-12-09 03:05:31","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"tPt371b21mA","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2146016,"started_at":"2020-12-07 11:21:38","seller":"Bloomx","buyer":"Arnz","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        11:27:19","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"FUCJbTJAXQo","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"55000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":6182943,"started_at":"2020-12-09 01:59:21","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        02:29:22","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"w56S4xYUdtR","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"68250.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":7715406,"started_at":"2020-12-09 01:26:50","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        01:56:52","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"mmdyawmcVny","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":226131,"started_at":"2020-12-09 01:00:50","seller":"Bloomx","buyer":"lynindkk","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        01:47:46","completed_at":"2020-12-09 01:47:46","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"fTfYkikwooj","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":225489,"started_at":"2020-12-09 00:51:52","seller":"Bloomx","buyer":"lynindkk","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        00:59:09","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"pEpZyhpkbRG","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":225489,"started_at":"2020-12-09 00:53:15","seller":"Bloomx","buyer":"lynindkk","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        00:58:45","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"EgqiBMvFAq2","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3900.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":436580,"started_at":"2020-12-08 23:58:06","seller":"Bloomx","buyer":"itsmikey","fiat_currency_code":"PHP","ended_at":"2020-12-09
+        00:10:52","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"Lp8rrzTbddL","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":224381,"started_at":"2020-12-08 23:29:07","seller":"Bloomx","buyer":"ArchTech_Icafe","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        23:40:15","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"7PkiB5nesTK","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":560953,"started_at":"2020-12-08 23:24:21","seller":"Bloomx","buyer":"ArchTech_Icafe","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        23:24:29","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"aNqFxQTNWtD","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":549862,"started_at":"2020-12-08 22:47:08","seller":"Bloomx","buyer":"CharMitchva","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        22:51:14","completed_at":"2020-12-08 22:51:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"qTeQjvL2mfP","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"11708.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1285481,"started_at":"2020-12-08 21:48:37","seller":"Bloomx","buyer":"Khabernardo","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        21:51:13","completed_at":"2020-12-08 21:51:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"qDmCGy2e2nb","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"24000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2637362,"started_at":"2020-12-08 21:00:52","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        21:30:54","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"qjfFfiACgnP","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1098003,"started_at":"2020-12-08 21:22:13","seller":"Bloomx","buyer":"Khabernardo","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        21:24:11","completed_at":"2020-12-08 21:24:11","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"UzXCJ8teFHp","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":219780,"started_at":"2020-12-08 21:04:35","seller":"Bloomx","buyer":"JoharKhan67","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        21:06:42","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"4yx3mZB4frj","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"22000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2402628,"started_at":"2020-12-08 18:53:33","seller":"Bloomx","buyer":"Coinspot70","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        18:56:16","completed_at":"2020-12-08 18:56:16","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"cw8LBhE1kaT","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4020.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":438532,"started_at":"2020-12-08 18:47:45","seller":"Bloomx","buyer":"jasperrobin","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        18:50:14","completed_at":"2020-12-08 18:50:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"Eoqeaq8toHT","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4240.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":462531,"started_at":"2020-12-08 18:40:16","seller":"Bloomx","buyer":"jasperrobin","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        18:43:14","completed_at":"2020-12-08 18:43:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"t1SKUiH1WM7","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3980.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":433385,"started_at":"2020-12-08 18:12:03","seller":"Bloomx","buyer":"jasperrobin","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        18:14:14","completed_at":"2020-12-08 18:14:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"cFFQFk3WQKL","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"18000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1955932,"started_at":"2020-12-08 18:04:51","seller":"Bloomx","buyer":"Mgrace27","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        18:07:15","completed_at":"2020-12-08 18:07:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"esgN7BLFppv","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"6390.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":694356,"started_at":"2020-12-08 18:00:36","seller":"Bloomx","buyer":"jasperrobin","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        18:04:14","completed_at":"2020-12-08 18:04:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"6PGtwUpq2S4","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"23999.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2614996,"started_at":"2020-12-08 16:31:54","seller":"Bloomx","buyer":"CNDYBT","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        16:36:17","completed_at":"2020-12-08 16:36:17","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"FaEyXHyaEbw","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"11000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1202198,"started_at":"2020-12-08 16:21:31","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        16:24:15","completed_at":"2020-12-08 16:24:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"EJbeCVyKPkW","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":546986,"started_at":"2020-12-08 15:55:35","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        15:58:15","completed_at":"2020-12-08 15:58:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"SowySEgxpq8","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1086468,"started_at":"2020-12-08 14:29:26","seller":"Bloomx","buyer":"Buenc","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        14:30:01","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"jQor16Rbmvf","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1634574,"started_at":"2020-12-08 13:56:47","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        13:59:23","completed_at":"2020-12-08 13:59:23","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"hbyddR3dS2z","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"13000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1421682,"started_at":"2020-12-08 12:26:02","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        12:29:11","completed_at":"2020-12-08 12:29:11","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"R2v411pnBFa","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":218746,"started_at":"2020-12-08 10:15:38","seller":"Bloomx","buyer":"JPF_PXL","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        10:45:40","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"Jo5bNzynchd","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":219067,"started_at":"2020-12-08 10:40:49","seller":"Bloomx","buyer":"ocn1984","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        10:41:52","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"pnDAbrsrqTm","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"1950.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":212878,"started_at":"2020-12-08 10:24:48","seller":"Bloomx","buyer":"Helen1994","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        10:38:15","completed_at":"2020-12-08 10:38:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"ydrWU4ud2P8","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5350.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":585146,"started_at":"2020-12-08 10:12:42","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        10:17:15","completed_at":"2020-12-08 10:17:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"sqpdtxtmear","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"11000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1193964,"started_at":"2020-12-08 09:45:36","seller":"Bloomx","buyer":"JayS3333","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        09:52:26","completed_at":"2020-12-08 09:52:26","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"Dz1Sm8bojZE","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1668397,"started_at":"2020-12-08 08:23:17","seller":"Bloomx","buyer":"lynindkk","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        09:01:53","completed_at":"2020-12-08 09:01:53","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"TZXWVCwvxDC","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":538192,"started_at":"2020-12-08 08:21:50","seller":"Bloomx","buyer":"Clover7","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        09:01:14","completed_at":"2020-12-08 09:01:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"7KVwKNuA1GZ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1665484,"started_at":"2020-12-08 08:05:26","seller":"Bloomx","buyer":"lynindkk","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        08:35:27","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"aBfk7k7DkxX","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1074588,"started_at":"2020-12-08 07:11:44","seller":"Bloomx","buyer":"JayS3333","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        07:42:59","completed_at":"2020-12-08 07:42:59","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"wuHf1ZZjvcu","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2149923,"started_at":"2020-12-08 07:07:43","seller":"Bloomx","buyer":"CharMitchva","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        07:37:48","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"qM4KhukhnNH","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"20000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2149923,"started_at":"2020-12-08 07:07:44","seller":"Bloomx","buyer":"CharMitchva","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        07:10:15","completed_at":"2020-12-08 07:10:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"kshkxg5cc4F","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":214992,"started_at":"2020-12-08 07:07:13","seller":"Bloomx","buyer":"CharMitchva","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        07:07:19","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"GgZCvjkcAqz","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"12000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1288790,"started_at":"2020-12-08 06:46:28","seller":"Bloomx","buyer":"escorpi","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        06:48:14","completed_at":"2020-12-08 06:48:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"DqVefyWrPC3","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7500.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":803580,"started_at":"2020-12-08 05:48:35","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        05:51:27","completed_at":"2020-12-08 05:51:27","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"omSuwBsN2YJ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"5000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":536628,"started_at":"2020-12-08 05:02:36","seller":"Bloomx","buyer":"martialmoney","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        05:07:17","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"YW12xr2QDbS","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"3580.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":383971,"started_at":"2020-12-08 04:49:00","seller":"Bloomx","buyer":"jasperrobin","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        04:50:15","completed_at":"2020-12-08 04:50:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"Ek5fsmLEvsE","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"13580.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1456517,"started_at":"2020-12-08 04:44:34","seller":"Bloomx","buyer":"jasperrobin","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        04:47:16","completed_at":"2020-12-08 04:47:16","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"qRk6iwf2WLn","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1072248,"started_at":"2020-12-08 04:39:36","seller":"Bloomx","buyer":"jasperrobin","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        04:42:17","completed_at":"2020-12-08 04:42:17","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"oW1tacghnsT","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1072248,"started_at":"2020-12-08 04:31:29","seller":"Bloomx","buyer":"jasperrobin","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        04:34:16","completed_at":"2020-12-08 04:34:16","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"HY3xtygav6A","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1071334,"started_at":"2020-12-08 04:28:09","seller":"Bloomx","buyer":"jasperrobin","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        04:30:18","completed_at":"2020-12-08 04:30:18","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"v1nmBLKViXy","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"30002.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":3214216,"started_at":"2020-12-08 04:26:06","seller":"Bloomx","buyer":"ElleWins","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        04:28:16","completed_at":"2020-12-08 04:28:16","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"W2wVM8kapYB","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1071334,"started_at":"2020-12-08 04:20:39","seller":"Bloomx","buyer":"jasperrobin","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        04:26:14","completed_at":"2020-12-08 04:26:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"9zD4Lsa6Hw3","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1074069,"started_at":"2020-12-08 03:22:46","seller":"Bloomx","buyer":"WYZZYPAX","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        03:25:16","completed_at":"2020-12-08 03:25:16","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"Wi4kJuAi8i1","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10400.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1115360,"started_at":"2020-12-08 03:19:44","seller":"Bloomx","buyer":"WYZZYPAX","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        03:22:14","completed_at":"2020-12-08 03:22:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"Psxe8xtvwf9","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1072661,"started_at":"2020-12-08 02:50:24","seller":"Bloomx","buyer":"angelarachelbee","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        02:52:17","completed_at":"2020-12-08 02:52:17","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"FCFyyXckx3x","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":214210,"started_at":"2020-12-08 02:04:44","seller":"Bloomx","buyer":"Clover7","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        02:23:46","completed_at":"2020-12-08 02:23:46","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"uRiDtpwjBWj","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":214210,"started_at":"2020-12-08 02:05:55","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        02:13:14","completed_at":"2020-12-08 02:13:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"xQPhZzYiU2n","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"19100.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2047080,"started_at":"2020-12-08 01:39:17","seller":"Bloomx","buyer":"mikoangelo","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        02:08:33","completed_at":"2020-12-08 02:08:33","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"PFjxfDzKrwx","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"28850.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":3089983,"started_at":"2020-12-08 02:03:58","seller":"Bloomx","buyer":"Coinspot70","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        02:08:14","completed_at":"2020-12-08 02:08:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"8wHwmsL1cWc","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"7000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":750993,"started_at":"2020-12-08 01:55:48","seller":"Bloomx","buyer":"lcswings","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        01:58:13","completed_at":"2020-12-08 01:58:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"u1FMKjmGMar","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"17000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1823567,"started_at":"2020-12-08 01:46:28","seller":"Bloomx","buyer":"Coinspot70","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        01:55:13","completed_at":"2020-12-08 01:55:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"t3cUsqtbggb","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"9359.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1005727,"started_at":"2020-12-08 00:10:34","seller":"Bloomx","buyer":"angelarachelbee","fiat_currency_code":"PHP","ended_at":"2020-12-08
+        00:14:14","completed_at":"2020-12-08 00:14:14","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"oCpBkkKAdHn","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":215772,"started_at":"2020-12-07 23:16:52","seller":"Bloomx","buyer":"Clover7","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        23:18:25","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"y7hPpVuubCT","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"19000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":2040130,"started_at":"2020-12-07 16:12:35","seller":"Bloomx","buyer":"Driclao","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        16:15:17","completed_at":"2020-12-07 16:15:17","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"wLhzCjbb6mk","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"10000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1072158,"started_at":"2020-12-07 16:08:20","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        16:12:13","completed_at":"2020-12-07 16:12:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"QxkedWFuWuW","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"49000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":5253572,"started_at":"2020-12-07 16:00:26","seller":"Bloomx","buyer":"Ikigai_25","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        16:05:12","completed_at":"2020-12-07 16:05:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"fwTnAknesJQ","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4750.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":509556,"started_at":"2020-12-07 14:50:42","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        14:54:15","completed_at":"2020-12-07 14:54:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"qq4RCux7HxE","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4750.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":509963,"started_at":"2020-12-07 14:09:40","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        14:16:15","completed_at":"2020-12-07 14:16:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"37uoajCiDTH","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":214545,"started_at":"2020-12-07 12:49:45","seller":"Bloomx","buyer":"Clover7","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        12:50:48","completed_at":null,"offer_type":"sell","status":"cancelled","crypto_currency_code":"BTC"},{"trade_hash":"QnfWTgxP1wU","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"33550.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":3610144,"started_at":"2020-12-07 10:10:53","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        10:54:48","completed_at":"2020-12-07 10:54:48","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"SzoJiUuAHq8","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2900.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":311694,"started_at":"2020-12-07 10:06:47","seller":"Bloomx","buyer":"TiptopZiege735","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        10:52:16","completed_at":"2020-12-07 10:52:16","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"DrBvKFcgduD","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"4000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":429747,"started_at":"2020-12-07 09:44:20","seller":"Bloomx","buyer":"user6c024cc1c","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        10:52:09","completed_at":"2020-12-07 10:52:09","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"ykLpgfyzQAF","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"46789.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":5021295,"started_at":"2020-12-07 10:39:31","seller":"Bloomx","buyer":"CNDYBT","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        10:45:15","completed_at":"2020-12-07 10:45:15","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"xs1uywCTt2p","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"2000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":214628,"started_at":"2020-12-07 09:14:02","seller":"Bloomx","buyer":"Clover7","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        09:44:04","completed_at":null,"offer_type":"sell","status":"expired","crypto_currency_code":"BTC"},{"trade_hash":"Sg4j4qXts78","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"460000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":49103512,"started_at":"2020-12-07 07:19:08","seller":"Bloomx","buyer":"Tcd999","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        07:30:37","completed_at":"2020-12-07 07:30:37","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"RDndDabYHJB","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"450000.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":48057632,"started_at":"2020-12-07 06:49:31","seller":"Bloomx","buyer":"Tcd999","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        07:18:27","completed_at":"2020-12-07 07:18:27","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"CaRdaFg1wzA","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"15200.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":1623280,"started_at":"2020-12-07 06:42:27","seller":"Bloomx","buyer":"EDNAMISA","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        07:18:12","completed_at":"2020-12-07 07:18:12","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"},{"trade_hash":"R9nCZYaKbWG","offer_hash":"pbg1ftsnPdH","fiat_amount_requested":"32800.00","payment_method_name":"Bank
+        Transfer","crypto_amount_requested":3501611,"started_at":"2020-12-07 06:51:54","seller":"Bloomx","buyer":"FreidaLeana","fiat_currency_code":"PHP","ended_at":"2020-12-07
+        06:55:13","completed_at":"2020-12-07 06:55:13","offer_type":"sell","status":"successful","crypto_currency_code":"BTC"}]}}'
+    http_version: 
+  recorded_at: Tue, 15 Dec 2020 09:30:02 GMT
 recorded_with: VCR 3.0.3

--- a/spec/paxful_client/responses/get_completed_trades_response_spec.rb
+++ b/spec/paxful_client/responses/get_completed_trades_response_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+module PaxfulClient
+  RSpec.describe GetCompletedTradesResponse do
+
+    describe "#success" do
+      context "empty body" do
+        let(:response) { described_class.new }
+        let(:empty_response) { described_class.new }
+
+        it "fails" do
+          json = { data: { trades: ["hello"] } }.with_indifferent_access
+          expect(response).to receive(:parsed_body).at_most(3).times
+            .and_return(json)
+          expect(response).to receive(:code).and_return(200)
+          expect(response).to be_success
+
+          expect(empty_response).to receive(:parsed_body).at_most(3).times
+            .and_return({})
+          expect(empty_response).to receive(:code).and_return(200)
+          expect(empty_response).not_to be_success
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
## Description
Consider the `.success?` method when called outside the gem to have more checks

## Bugsnag
https://app.bugsnag.com/bloomsolutions/bloom-trade/errors/5fce097eb6565b0018926376?filters[event.since][0]=7d&filters[error.status][0][type]=eq&filters[error.status][0][value]=open&filters[app.release_stage][0][value]=production&filters[app.release_stage][0][type]=eq