### PR TITLE
feat: GetBalanceResponse#success? now checks for the response body as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [TBA]
+### Changed
+- `get_balance#success?` now checks if the response body has a `data` element. Sometimes Paxful returns 200, but has an empty body
+
 ## [1.2.0] - 2020-12-15
 ### Changed
 - Only consider success for `get_completed_trades` if it meets certain criteria

--- a/lib/paxful_client/responses/base_response.rb
+++ b/lib/paxful_client/responses/base_response.rb
@@ -5,6 +5,7 @@ module PaxfulClient
 
     attribute :body, Object, lazy: true, default: :default_body
     attribute :parsed_body, String, lazy: true, default: :default_parsed_body
+    attribute :error_message, String, lazy: true
 
     private
 

--- a/lib/paxful_client/responses/get_balance_response.rb
+++ b/lib/paxful_client/responses/get_balance_response.rb
@@ -1,13 +1,19 @@
 module PaxfulClient
-  class GetBalanceResponse
-
-    include APIClientBase::Response.module
+  class GetBalanceResponse < BaseResponse
 
     attribute :wallet, PaxfulClient::Wallet, lazy: true, default: :default_wallet
     attribute :body, Object, lazy: true, default: :default_body
     attribute :parsed_body, String, lazy: true, default: :default_parsed_body
 
     private
+
+    def default_success
+      unless parsed_body['data'].present?
+        self.error_message = 'GetBalanceResponse: data not present'
+        return false
+      end
+      raw_response.success?
+    end
 
     def default_wallet
       args = parsed_body["data"].each_with_object({}) do |(attr, val), hash|

--- a/spec/paxful_client/responses/get_balance_response_spec.rb
+++ b/spec/paxful_client/responses/get_balance_response_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+module PaxfulClient
+  RSpec.describe GetBalanceResponse do
+
+    describe "#success" do
+      context "empty data body" do
+        let(:response) { described_class.new }
+        let(:empty_response) { described_class.new }
+
+        it "fails" do
+          json = {
+            data: { incoming_amount: 1000, balance: 1000 }
+          }.with_indifferent_access
+          response.parsed_body = json
+          response.raw_response = double(Typhoeus::Response, success?: true)
+          expect(response).to be_success
+
+          empty_response.parsed_body = {}
+          empty_response.raw_response = double(Typhoeus::Response, {
+            success?: true,
+          })
+          expect(empty_response).not_to be_success
+          expect(empty_response.error_message)
+            .to eq "GetBalanceResponse: data not present"
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Sometimes the API might return a 200 success, but the body is empty, or it doesn't contain the JSON we expect